### PR TITLE
feat: index all Zotero libraries (user + groups)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to ZotSeek - Semantic Search for Zotero will be documented in this file.
 
+## [1.18.0] - 2026-07-17
+
+### Added
+- **Group library indexing (opt-in)** (#41) — a new **Index scope** setting in **Settings → ZotSeek → Auto-Indexing** chooses which libraries ZotSeek covers: **My Library** (default) or **All libraries** (personal + groups). The scope governs both the bulk **Update Index** action and background auto-indexing. Group items already appear in search results once indexed, with correct deep links into the group library. Contributed by @wjma-phy (#40).
+- `library_key` parameter on the MCP `search` tool and `libraryKey` on `GET /zotseek/search` — limit a search to the personal library (`user`) or a single group (`group:<groupID>`); omit to search everything indexed. Brings `search` to parity with `find_similar`, which already accepted `library_key`.
+
+### Changed
+- **Auto-indexing now respects the index scope** — previously auto-index processed new items from *any* library (group items included) while the bulk Update Index action covered only My Library. Both paths now follow the Index scope setting, so the default behavior is consistently My Library only. If you relied on group items being auto-indexed, set Index scope to **All libraries**.
+- The Update Index confirmation dialog now states which scope it will index ("your personal library" vs "all your libraries").
+
+### Technical
+- New `zotseek.indexScope` preference (`"user"` default | `"all"`), read by both `onIndexLibrary()` (bulk) and `AutoIndexManager.shouldProcess()`.
+- `ZoteroAPI.getAllLibraries()` / `getAllLibraryItems()` enumerate user + group libraries (feeds excluded); `getCollectionItems()` accepts an optional `libraryId` so collection indexing works in group libraries (fixes bulk-resume in group collections).
+- REST/MCP `library_key` resolution validates unknown groups: `group:<id>` for a group Zotero doesn't have returns an explicit error instead of silently searching nothing.
+
+---
+
 ## [1.17.0] - 2026-07-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Find similar papers by **meaning**, not just keywords. 100% local, no data leave
 - 📁 **Save Results as Collection** - One click saves the full result set into a new Zotero collection so you can revisit the list later without re-running the search
 - 🧩 **Selectable Embedding Models** - Choose from 4 curated local models, including multilingual options; non-bundled models download once from Hugging Face to your machine
 - 🔄 **Auto-Index** - Automatically index new papers when you add them to your library
+- 👥 **Group Libraries (opt-in)** - Extend indexing and search to your Zotero group libraries with the Index scope setting
 - 🗑️ **Auto-Cleanup** - Embeddings automatically removed when items are deleted or trashed
 - 🚫 **Tag-Based Exclusion** - Tag items with `zotseek-exclude` to skip them during indexing
 - 📊 **Indexing Status Column** - "ZotSeek" column in the item list shows whether each paper is fully indexed, partially indexed (chunk limit hit), out of date, excluded, or not indexed
@@ -237,6 +238,17 @@ For technical details, see [docs/SEARCH_ARCHITECTURE.md](docs/SEARCH_ARCHITECTUR
 | **Full Document** (default) | PDF content split by sections | Deep content search, better results |
 
 Configure via **Zotero → Settings → ZotSeek**.
+
+### Library Scope (Group Libraries)
+
+By default, ZotSeek indexes only **My Library**. If you use Zotero group libraries, the **Index scope** setting (under Auto-Indexing) lets you include them:
+
+| Scope | What Gets Indexed |
+|-------|-------------------|
+| **My Library** (default) | Your personal library only |
+| **All libraries** | Personal library + every group library |
+
+The scope applies to both the bulk **Update Index** action and background auto-indexing. Once indexed, group items show up in search results like any other paper, with links that open them in the right library. Searches over MCP/REST can also be limited to a single library with the `library_key` parameter (see [docs/MCP.md](docs/MCP.md)).
 
 ### How Full Document Mode Works
 

--- a/content/preferences.xhtml
+++ b/content/preferences.xhtml
@@ -282,6 +282,19 @@
   <html:p style="color: var(--zotseek-text-secondary); font-size: 11px; margin: 4px 0 0 24px;">
     <html:span data-l10n-id="zotseek-pref-delayDesc">Wait this long after the last item is added before starting auto-indexing.</html:span>
   </html:p>
+
+  <html:div style="margin: 12px 0 0 24px; display: flex; align-items: center; gap: 8px;">
+    <html:label data-l10n-id="zotseek-pref-indexScope" for="zotseek-pref-indexScope" style="color: var(--zotseek-text-primary); font-size: 12px;">Index scope:</html:label>
+    <menulist id="zotseek-pref-indexScope" native="true">
+      <menupopup>
+        <menuitem label="My Library" value="user" data-l10n-id="zotseek-pref-indexScopeUser" />
+        <menuitem label="All libraries" value="all" data-l10n-id="zotseek-pref-indexScopeAll" />
+      </menupopup>
+    </menulist>
+  </html:div>
+  <html:p style="color: var(--zotseek-text-secondary); font-size: 11px; margin: 4px 0 0 24px;">
+    <html:span data-l10n-id="zotseek-pref-indexScopeDesc">Choose which libraries are included when updating or auto-indexing the index.</html:span>
+  </html:p>
 </groupbox>
 
 <!-- Search Settings -->

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -47,11 +47,13 @@ Any other MCP client that supports the HTTP transport works the same way (for ex
 
 | Tool | Arguments | Returns |
 |------|-----------|---------|
-| `search` | `query` *(required)*; `max_results` (1–100, default 10); `mode` (`hybrid` \| `semantic` \| `keyword`, default `hybrid`); `granularity` (`papers` \| `passages`, default `papers`); `min_similarity` (0–1, defaults to your ZotSeek preference) | Ranked results from a semantic/keyword search over the library |
+| `search` | `query` *(required)*; `max_results` (1–100, default 10); `mode` (`hybrid` \| `semantic` \| `keyword`, default `hybrid`); `granularity` (`papers` \| `passages`, default `papers`); `min_similarity` (0–1, defaults to your ZotSeek preference); `library_key` (`user` or `group:<groupID>`, omit to search all indexed libraries) | Ranked results from a semantic/keyword search over the library |
 | `find_similar` | `item_key` *(required, 8-character Zotero key)*; `library_key` (`user` or `group:<groupID>`, default `user`); `max_results` (1–100, default 10) | Papers similar to a known library item, by its stored embeddings |
 | `index_status` | *(none)* | `{ready, modelLoaded, indexedPapers, totalChunks, modelId, activeModel, coverage, lastIndexed, storageUsedBytes}` |
 
 `mode` mirrors the ZotSeek UI: **hybrid** fuses semantic and keyword results with RRF, honoring your ZotSeek preferences including automatic weight adjustment, so it returns the same ranking you see in the ZotSeek dialog; **semantic** uses embeddings only (same code path as the [JS API](API.md)'s `search()`); **keyword** uses Zotero's keyword search only. `granularity` controls whether you get one result per paper (`papers`, best-matching chunk) or every matching chunk as its own result (`passages`).
+
+`library_key` narrows `search` to a single library; when omitted, results come from every indexed library. Note the different default on `find_similar`: there `library_key` identifies the library of the *source* item and defaults to `user`.
 
 For `index_status`, `ready` is `true` when the index contains papers; the embedding model itself lazy-loads on the first search, adding ~30s to that first call when `modelLoaded` is `false`. `modelLoaded` reports whether that pipeline is already warm. A `ready: true, modelLoaded: false` status means searches will work but the first one will be slow. `activeModel` is the short identifier of the currently configured embedding model (e.g. `"bge-m3"`). `coverage` is `{ covered, total }` — the number of library items indexed under that model vs. the total items in the index, letting agents detect when a model switch has left items to be re-indexed.
 
@@ -111,7 +113,7 @@ The same operations and result shapes are available as plain `GET` endpoints for
 
 | Endpoint | Query parameters |
 |----------|------------------|
-| `GET /zotseek/search` | `q` *(required)*, `topK`, `mode`, `granularity`, `minSimilarity` (0–1) |
+| `GET /zotseek/search` | `q` *(required)*, `topK`, `mode`, `granularity`, `minSimilarity` (0–1), `libraryKey` (`user` or `group:N`, omit to search all indexed libraries) |
 | `GET /zotseek/similar` | `itemKey` *(required)*, `libraryKey` (`user` or `group:N`), `topK` |
 | `GET /zotseek/stats` | *(none)* |
 | `GET /zotseek/open` | `target` (`select` \| `pdf`) *(required)*, `key` *(required)*, `library` (`user` or `group:N`), `page` (pdf only) — selects the item or opens the PDF directly in Zotero and returns a confirmation page (`404` if the item isn't in this library) |

--- a/locale/en-US/zotseek.ftl
+++ b/locale/en-US/zotseek.ftl
@@ -8,7 +8,7 @@ zotseek-menu-findSimilar = Find Similar Documents
 zotseek-menu-openZotSeek = Open ZotSeek...
 zotseek-menu-indexSelected = Index Selected for ZotSeek
 zotseek-menu-indexCollection = Index Current Collection
-zotseek-menu-updateLibrary = Update Library Index
+zotseek-menu-updateLibrary = Update All Libraries Index
 zotseek-menu-removeFromIndex = Remove from ZotSeek Index
 zotseek-menu-findRelated = Find Related Documents
 
@@ -261,12 +261,12 @@ zotseek-indexing-selectCollection = Please select a collection first.
     (Click on a collection in the left sidebar)
 zotseek-indexing-emptyCollection = Collection "{ $name }" has no items to index.
 zotseek-indexing-updateTitle = ZotSeek - Update Library Index
-zotseek-indexing-updateConfirmMsg = This will index all unindexed items in your library for semantic search.
+zotseek-indexing-updateConfirmMsg = This will index all unindexed items in all your libraries (personal + groups) for semantic search.
 
 # Auto-resume prompt shown at startup when a previous bulk-index run was interrupted.
 zotseek-resume-title = ZotSeek - Resume Indexing
 zotseek-resume-message = A previous indexing run was interrupted. { $count } item(s) in { $scope } are still pending. Resume now?
-zotseek-resume-scopeLibrary = your library
+zotseek-resume-scopeLibrary = your libraries
 zotseek-resume-scopeCollection = the "{ $name }" collection
 
     Items that are already indexed will be skipped.

--- a/locale/en-US/zotseek.ftl
+++ b/locale/en-US/zotseek.ftl
@@ -8,7 +8,7 @@ zotseek-menu-findSimilar = Find Similar Documents
 zotseek-menu-openZotSeek = Open ZotSeek...
 zotseek-menu-indexSelected = Index Selected for ZotSeek
 zotseek-menu-indexCollection = Index Current Collection
-zotseek-menu-updateLibrary = Update All Libraries Index
+zotseek-menu-updateLibrary = Update Library Index
 zotseek-menu-removeFromIndex = Remove from ZotSeek Index
 zotseek-menu-findRelated = Find Related Documents
 
@@ -55,10 +55,16 @@ zotseek-pref-mcpServerWarning = Zotero's local HTTP server is disabled. Enable "
 zotseek-pref-autoIndexing = Auto-Indexing
 zotseek-pref-autoIndexLabel =
     .label = Automatically index new items
-zotseek-pref-autoIndexDesc = New papers with PDFs are indexed in the background when added to your library.
+zotseek-pref-autoIndexDesc = New papers with PDFs are indexed in the background when added to the selected libraries.
 zotseek-pref-delayLabel = Delay before indexing:
 zotseek-pref-seconds = seconds
 zotseek-pref-delayDesc = Wait this long after the last item is added before starting auto-indexing.
+zotseek-pref-indexScope = Index scope
+zotseek-pref-indexScopeUser =
+ .label = My Library
+zotseek-pref-indexScopeAll =
+ .label = All libraries
+zotseek-pref-indexScopeDesc = Choose which libraries are included when updating or auto-indexing the index.
 zotseek-pref-searchSettings = Search Settings
 zotseek-pref-resultsToShow = Results to show
 zotseek-pref-resultsToShowDesc = How many matches to display (5-100)
@@ -78,7 +84,7 @@ zotseek-pref-actions = Actions
 zotseek-pref-updateIndex =
     .label = Update Index
 zotseek-pref-recommended = ✓ Recommended
-zotseek-pref-updateIndexDesc = Index all unindexed items in your library. Resumes safely from where you left off.
+zotseek-pref-updateIndexDesc = Index all unindexed items in the selected libraries. Resumes safely from where you left off.
 zotseek-pref-rebuildIndex =
     .label = Rebuild Index
 zotseek-pref-rebuildIndexDesc = Clear and re-index all items with current settings. Use after changing indexing mode.
@@ -261,12 +267,15 @@ zotseek-indexing-selectCollection = Please select a collection first.
     (Click on a collection in the left sidebar)
 zotseek-indexing-emptyCollection = Collection "{ $name }" has no items to index.
 zotseek-indexing-updateTitle = ZotSeek - Update Library Index
-zotseek-indexing-updateConfirmMsg = This will index all unindexed items in all your libraries (personal + groups) for semantic search.
+zotseek-indexing-updateConfirmMsg = This will index all unindexed items in { $scope } for semantic search.
+zotseek-indexing-scopeUser = your personal library
+zotseek-indexing-scopeAll = all your libraries (personal + groups)
 
 # Auto-resume prompt shown at startup when a previous bulk-index run was interrupted.
 zotseek-resume-title = ZotSeek - Resume Indexing
 zotseek-resume-message = A previous indexing run was interrupted. { $count } item(s) in { $scope } are still pending. Resume now?
 zotseek-resume-scopeLibrary = your libraries
+zotseek-resume-scopeUserLibrary = your personal library
 zotseek-resume-scopeCollection = the "{ $name }" collection
 
     Items that are already indexed will be skipped.

--- a/locale/zh-CN/zotseek.ftl
+++ b/locale/zh-CN/zotseek.ftl
@@ -8,7 +8,7 @@ zotseek-menu-findSimilar = 查找相似文献
 zotseek-menu-openZotSeek = 打开 ZotSeek...
 zotseek-menu-indexSelected = 为 ZotSeek 索引选中项
 zotseek-menu-indexCollection = 索引当前合集
-zotseek-menu-updateLibrary = 更新所有文献库索引
+zotseek-menu-updateLibrary = 更新文献库索引
 zotseek-menu-removeFromIndex = 从 ZotSeek 索引中移除
 zotseek-menu-findRelated = 查找相关文献
 
@@ -55,10 +55,16 @@ zotseek-pref-mcpServerWarning = Zotero 的本地 HTTP 服务器已禁用。请�
 zotseek-pref-autoIndexing = 自动索引
 zotseek-pref-autoIndexLabel =
     .label = 自动索引新条目
-zotseek-pref-autoIndexDesc = 添加到文献库的新文献将在后台自动索引。
+zotseek-pref-autoIndexDesc = 添加到所选文献库的新文献将在后台自动索引。
 zotseek-pref-delayLabel = 索引前延迟：
 zotseek-pref-seconds = 秒
 zotseek-pref-delayDesc = 添加最后一个条目后等待这么长时间再开始自动索引。
+zotseek-pref-indexScope = 索引范围
+zotseek-pref-indexScopeUser =
+ .label = 我的文献库
+zotseek-pref-indexScopeAll =
+ .label = 所有文献库
+zotseek-pref-indexScopeDesc = 选择更新索引或自动索引时包含哪些文献库。
 zotseek-pref-searchSettings = 搜索设置
 zotseek-pref-resultsToShow = 显示结果数
 zotseek-pref-resultsToShowDesc = 显示多少个匹配结果（5-100）
@@ -78,7 +84,7 @@ zotseek-pref-actions = 操作
 zotseek-pref-updateIndex =
     .label = 更新索引
 zotseek-pref-recommended = ✓ 推荐
-zotseek-pref-updateIndexDesc = 索引文献库中所有未索引的条目。可从上次中断处安全恢复。
+zotseek-pref-updateIndexDesc = 索引所选文献库中所有未索引的条目。可从上次中断处安全恢复。
 zotseek-pref-rebuildIndex =
     .label = 重建索引
 zotseek-pref-rebuildIndexDesc = 清除并使用当前设置重新索引所有条目。更改索引模式后使用。
@@ -261,12 +267,15 @@ zotseek-indexing-selectCollection = 请先选择一个合集。
     （在左侧边栏中点击一个合集）
 zotseek-indexing-emptyCollection = 合集"{ $name }"没有可索引的条目。
 zotseek-indexing-updateTitle = ZotSeek - 更新文献库索引
-zotseek-indexing-updateConfirmMsg = 这将为所有文献库（个人库 + 群组库）中未索引的条目建立语义搜索索引。
+zotseek-indexing-updateConfirmMsg = 这将为{ $scope }中未索引的条目建立语义搜索索引。
+zotseek-indexing-scopeUser = 您的个人文献库
+zotseek-indexing-scopeAll = 您的所有文献库（个人 + 群组）
 
 # 启动时检测到先前中断的索引任务时显示的恢复提示。
 zotseek-resume-title = ZotSeek - 恢复索引
 zotseek-resume-message = 上一次索引被中断。{ $scope }中仍有 { $count } 个条目待处理。现在恢复？
 zotseek-resume-scopeLibrary = 您的所有文献库
+zotseek-resume-scopeUserLibrary = 您的个人文献库
 zotseek-resume-scopeCollection = "{ $name }" 收藏夹
 
     已索引的条目将被跳过。

--- a/locale/zh-CN/zotseek.ftl
+++ b/locale/zh-CN/zotseek.ftl
@@ -8,7 +8,7 @@ zotseek-menu-findSimilar = 查找相似文献
 zotseek-menu-openZotSeek = 打开 ZotSeek...
 zotseek-menu-indexSelected = 为 ZotSeek 索引选中项
 zotseek-menu-indexCollection = 索引当前合集
-zotseek-menu-updateLibrary = 更新文献库索引
+zotseek-menu-updateLibrary = 更新所有文献库索引
 zotseek-menu-removeFromIndex = 从 ZotSeek 索引中移除
 zotseek-menu-findRelated = 查找相关文献
 
@@ -261,12 +261,12 @@ zotseek-indexing-selectCollection = 请先选择一个合集。
     （在左侧边栏中点击一个合集）
 zotseek-indexing-emptyCollection = 合集"{ $name }"没有可索引的条目。
 zotseek-indexing-updateTitle = ZotSeek - 更新文献库索引
-zotseek-indexing-updateConfirmMsg = 这将为文献库中所有未索引的条目建立语义搜索索引。
+zotseek-indexing-updateConfirmMsg = 这将为所有文献库（个人库 + 群组库）中未索引的条目建立语义搜索索引。
 
 # 启动时检测到先前中断的索引任务时显示的恢复提示。
 zotseek-resume-title = ZotSeek - 恢复索引
 zotseek-resume-message = 上一次索引被中断。{ $scope }中仍有 { $count } 个条目待处理。现在恢复？
-zotseek-resume-scopeLibrary = 您的文献库
+zotseek-resume-scopeLibrary = 您的所有文献库
 zotseek-resume-scopeCollection = "{ $name }" 收藏夹
 
     已索引的条目将被跳过。

--- a/prefs.js
+++ b/prefs.js
@@ -7,6 +7,9 @@ pref("extensions.zotero.zotseek.topK", 20);
 pref("extensions.zotero.zotseek.autoIndex", false);
 pref("extensions.zotero.zotseek.autoIndexDelay", 10);
 
+// Index scope: "user" (My Library only) or "all" (all libraries including groups)
+pref("extensions.zotero.zotseek.indexScope", "user");
+
 // Indexing mode: "abstract" (title+abstract) or "full" (abstract + PDF sections)
 pref("extensions.zotero.zotseek.indexingMode", "abstract");
 

--- a/src/core/auto-index-manager.ts
+++ b/src/core/auto-index-manager.ts
@@ -250,6 +250,19 @@ export class AutoIndexManager {
       // Ignore tag check errors
     }
 
+    // Respect index scope preference
+    try {
+      const indexScope = Zotero.Prefs.get('zotseek.indexScope', true);
+      if (indexScope === 'user') {
+        const userLibraryID = Zotero.Libraries.userLibraryID;
+        if (item.libraryID !== userLibraryID) {
+          return false;
+        }
+      }
+    } catch {
+      // Ignore preference errors
+    }
+
     return true;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,6 +170,7 @@ class ZotSeekPlugin {
       'zotseek.indexStatusColumn.firstShown': false, // First-run flag for index-status column
       'zotseek.mcpServer.enabled': false, // Opt-in local MCP/REST endpoints for AI agents
       'zotseek.embeddingModel': 'nomic-embed-text-v1.5',
+      'zotseek.indexScope': 'user', // 'user' (My Library) or 'all' (all libraries)
     };
 
     for (const [key, defaultValue] of Object.entries(defaults)) {
@@ -328,7 +329,10 @@ class ZotSeekPlugin {
         label = getString('resume-scopeLibrary');
       } else if (scope.type === 'library') {
         items = await this.zoteroAPI.getLibraryItems(scope.libraryId);
-        label = getString('resume-scopeLibrary');
+        const userLibraryID = Z.Libraries.userLibraryID;
+        label = scope.libraryId === userLibraryID
+          ? getString('resume-scopeUserLibrary')
+          : getString('resume-scopeLibrary');
       } else {
         items = await this.zoteroAPI.getCollectionItems(scope.collectionId, scope.libraryId);
         const collection = await Z.Collections.getAsync(scope.collectionId);
@@ -989,8 +993,24 @@ class ZotSeekPlugin {
   }
 
   /**
+   * Read the user's index scope preference.
+   * 'user' = My Library only, 'all' = all libraries (user + groups).
+   */
+  private getIndexScope(): 'user' | 'all' {
+    const Z = getZotero();
+    try {
+      const scope = Z?.Prefs.get('zotseek.indexScope', true);
+      if (scope === 'all') return 'all';
+    } catch (e: any) {
+      this.logger.debug(`Could not read indexScope pref: ${e?.message || e}`);
+    }
+    return 'user';
+  }
+
+  /**
    * Index all libraries (user + groups)
    */
+
   private async onIndexLibrary(): Promise<void> {
     if (this.indexing) {
       this.showAlert(getString('indexing-alreadyInProgress'));
@@ -1000,20 +1020,34 @@ class ZotSeekPlugin {
     const Z = getZotero();
     if (!Z) return;
 
-    // Use Services.prompt for Zotero 8 compatibility
+    const scope = this.getIndexScope();
+    const userLibraryID = Z.Libraries.userLibraryID;
+
+    let items: any[];
+    let bulkScope: BulkScope;
+    let scopeLabel: string;
+    if (scope === 'all') {
+      this.logger.info('Indexing all libraries');
+      items = await this.zoteroAPI.getAllLibraryItems();
+      bulkScope = { type: 'all-libraries' };
+      scopeLabel = getString('indexing-scopeAll');
+    } else {
+      this.logger.info('Indexing user library only');
+      items = await this.zoteroAPI.getLibraryItems(userLibraryID);
+      bulkScope = { type: 'library', libraryId: userLibraryID };
+      scopeLabel = getString('indexing-scopeUser');
+    }
+    this.logger.info(`Found ${items.length} items to index`);
+
     const confirmed = Services.prompt.confirm(
       Z.getMainWindow(),
       getString('indexing-updateTitle'),
-      getString('indexing-updateConfirmMsg')
+      getString('indexing-updateConfirmMsg', { scope: scopeLabel })
     );
 
     if (!confirmed) return;
 
-    this.logger.info('Indexing all libraries');
-    const items = await this.zoteroAPI.getAllLibraryItems();
-    this.logger.info(`Found ${items.length} items to index across all libraries`);
-
-    await this.indexItems(items, { type: 'all-libraries' });
+    await this.indexItems(items, bulkScope);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ import './dev/suites/task-37e-model-download';
  */
 type BulkScope =
   | { type: 'library'; libraryId: number }
+  | { type: 'all-libraries' }
   | { type: 'collection'; libraryId: number; collectionId: number };
 
 interface PluginInfo {
@@ -322,11 +323,14 @@ class ZotSeekPlugin {
     let items: any[] = [];
     let label = '';
     try {
-      if (scope.type === 'library') {
-        items = await this.zoteroAPI.getLibraryItems();
+      if (scope.type === 'all-libraries') {
+        items = await this.zoteroAPI.getAllLibraryItems();
+        label = getString('resume-scopeLibrary');
+      } else if (scope.type === 'library') {
+        items = await this.zoteroAPI.getLibraryItems(scope.libraryId);
         label = getString('resume-scopeLibrary');
       } else {
-        items = await this.zoteroAPI.getCollectionItems(scope.collectionId);
+        items = await this.zoteroAPI.getCollectionItems(scope.collectionId, scope.libraryId);
         const collection = await Z.Collections.getAsync(scope.collectionId);
         label = collection?.name
           ? getString('resume-scopeCollection', { name: collection.name })
@@ -685,7 +689,7 @@ class ZotSeekPlugin {
   }
 
   /**
-   * Public method to index the entire library (called from preferences pane)
+   * Public method to index all libraries (called from preferences pane)
    */
   public indexLibrary(): void {
     this.onIndexLibrary();
@@ -985,7 +989,7 @@ class ZotSeekPlugin {
   }
 
   /**
-   * Index entire library
+   * Index all libraries (user + groups)
    */
   private async onIndexLibrary(): Promise<void> {
     if (this.indexing) {
@@ -1005,12 +1009,11 @@ class ZotSeekPlugin {
 
     if (!confirmed) return;
 
-    this.logger.info('Indexing entire library');
-    const items = await this.zoteroAPI.getLibraryItems();
-    this.logger.info(`Found ${items.length} items to index`);
+    this.logger.info('Indexing all libraries');
+    const items = await this.zoteroAPI.getAllLibraryItems();
+    this.logger.info(`Found ${items.length} items to index across all libraries`);
 
-    const libraryId = (Z.Libraries?.userLibraryID ?? items[0]?.libraryID ?? 1) as number;
-    await this.indexItems(items, { type: 'library', libraryId });
+    await this.indexItems(items, { type: 'all-libraries' });
   }
 
   /**

--- a/src/server/http-tools.ts
+++ b/src/server/http-tools.ts
@@ -55,6 +55,8 @@ export interface SearchToolArgs {
   granularity?: 'papers' | 'passages';
   /** 0-1; defaults to the user's minSimilarityPercent preference */
   min_similarity?: number;
+  /** 'user' for the personal library, or 'group:<groupID>' to limit the search to one group library. Omit to search all indexed libraries. */
+  library_key?: string;
 }
 
 export interface FindSimilarToolArgs {
@@ -202,6 +204,20 @@ export function isAllowedOrigin(origin: string | null | undefined): boolean {
   return /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i.test(origin);
 }
 
+function resolveLibraryId(libraryKey: string | undefined): number | undefined {
+  if (!libraryKey || typeof libraryKey !== 'string') return undefined;
+  const key = libraryKey.trim();
+  if (!key || key === 'user') return Zotero.Libraries.userLibraryID;
+  if (key.startsWith('group:')) {
+    const groupId = Number(key.slice('group:'.length).trim());
+    if (!Number.isFinite(groupId) || groupId <= 0) {
+      throw new Error(`search: invalid group library key "${libraryKey}"`);
+    }
+    return Zotero.Groups.getLibraryIDFromGroupID(groupId);
+  }
+  throw new Error(`search: library_key must be "user" or "group:<groupID>", got "${libraryKey}"`);
+}
+
 export async function runSearchTool(args: SearchToolArgs): Promise<{ results: ToolResultItem[] }> {
   if (!args || typeof args.query !== 'string' || !args.query.trim()) {
     throw new Error('search: "query" is required and must be a non-empty string');
@@ -213,7 +229,11 @@ export async function runSearchTool(args: SearchToolArgs): Promise<{ results: To
     args.min_similarity !== undefined
       ? clampFloat(args.min_similarity, 0, 1, prefMinSimilarity())
       : prefMinSimilarity();
-  const options = { mode, finalTopK, returnAllChunks, minSimilarity };
+  const libraryId = resolveLibraryId(args.library_key);
+  const options: any = { mode, finalTopK, returnAllChunks, minSimilarity };
+  if (libraryId !== undefined) {
+    options.libraryId = libraryId;
+  }
   // Mirror the UI (search-dialog-vtable): hybrid mode with the auto-adjust
   // pref uses smartSearch, which analyzes the query and tunes the
   // semantic/keyword weight. Without this, MCP/REST hybrid ran a fixed

--- a/src/server/http-tools.ts
+++ b/src/server/http-tools.ts
@@ -213,7 +213,11 @@ function resolveLibraryId(libraryKey: string | undefined): number | undefined {
     if (!Number.isFinite(groupId) || groupId <= 0) {
       throw new Error(`search: invalid group library key "${libraryKey}"`);
     }
-    return Zotero.Groups.getLibraryIDFromGroupID(groupId);
+    const libraryId = Zotero.Groups.getLibraryIDFromGroupID(groupId);
+    if (libraryId === false) {
+      throw new Error(`search: unknown group library for group ${groupId}`);
+    }
+    return libraryId;
   }
   throw new Error(`search: library_key must be "user" or "group:<groupID>", got "${libraryKey}"`);
 }

--- a/src/server/mcp-endpoint.ts
+++ b/src/server/mcp-endpoint.ts
@@ -75,6 +75,12 @@ const TOOL_DEFINITIONS = [
             'papers = one result per paper (best-matching chunk); ' +
             'passages = every matching chunk as its own result',
         },
+        library_key: {
+          type: 'string',
+          description:
+            "'user' for the personal library, or 'group:<groupID>' to limit the search to one group library. " +
+            'Omit to search all indexed libraries.',
+        },
       },
       required: ['query'],
     },

--- a/src/server/rest-endpoints.ts
+++ b/src/server/rest-endpoints.ts
@@ -41,6 +41,7 @@ export async function handleSearchRequest(requestData: any): Promise<EndpointRes
   try {
     const payload = await runSearchTool({
       query: q,
+      library_key: sp.get('libraryKey') || undefined,
       max_results: sp.get('topK') ? parseInt(sp.get('topK') as string, 10) : undefined,
       mode: (sp.get('mode') as any) || undefined,
       granularity: (sp.get('granularity') as any) || undefined,

--- a/src/ui/preferences.ts
+++ b/src/ui/preferences.ts
@@ -239,6 +239,7 @@ class PreferencesManager {
       autoIndex: Z.Prefs.get('zotseek.autoIndex', true) ?? false,
       autoIndexDelay: Z.Prefs.get('zotseek.autoIndexDelay', true) ?? 10,
       mcpServer: Z.Prefs.get('zotseek.mcpServer.enabled', true) ?? false,
+      indexScope: Z.Prefs.get('zotseek.indexScope', true) || 'user',
     };
 
     this.logger.debug(`Loaded preferences: ${JSON.stringify(prefs)}`);
@@ -267,6 +268,9 @@ class PreferencesManager {
 
     // Set text input values
     this.setInputValue('zotseek-pref-excludeTag', prefs.excludeTag);
+
+    // Set index scope menulist
+    this.setMenulistValue('zotseek-pref-indexScope', prefs.indexScope);
 
     // Update mode cards to match current selection
     this.updateModeCards();
@@ -451,6 +455,18 @@ class PreferencesManager {
         Z.Prefs.set('zotseek.mcpServer.enabled', checked, true);
         this.logger.info(`MCP server enabled changed to: ${checked}`);
         this.updateMcpServerVisibility(checked);
+      });
+    }
+
+    // Index scope change
+    const indexScopeMenu = doc.getElementById('zotseek-pref-indexScope') as any;
+    if (indexScopeMenu) {
+      indexScopeMenu.addEventListener('command', () => {
+        const value = indexScopeMenu.selectedItem?.value;
+        if (value) {
+          Z.Prefs.set('zotseek.indexScope', value, true);
+          this.logger.info(`Index scope changed to: ${value}`);
+        }
       });
     }
 

--- a/src/utils/zotero-api.ts
+++ b/src/utils/zotero-api.ts
@@ -82,10 +82,10 @@ export class ZoteroAPI {
    * Get all items in a collection using Search API
    * Reference: https://windingwind.github.io/doc-for-zotero-plugin-dev/main/search-operations.html
    */
-  async getCollectionItems(collectionId: number): Promise<ZoteroItem[]> {
+  async getCollectionItems(collectionId: number, libraryId?: number): Promise<ZoteroItem[]> {
     try {
       const s = new Zotero.Search();
-      s.libraryID = Zotero.Libraries.userLibraryID;
+      s.libraryID = libraryId || Zotero.Libraries.userLibraryID;
       s.addCondition('collectionID', 'is', collectionId);
       s.addCondition('recursive', 'true');  // Include subcollections
       s.addCondition('itemType', 'isNot', 'attachment');
@@ -127,6 +127,44 @@ export class ZoteroAPI {
       debug(`Failed to get library items: ${error}`);
       return [];
     }
+  }
+
+  /**
+   * Get all indexable libraries (user + groups, excluding feeds).
+   */
+  getAllLibraries(): Array<{ libraryID: number; name: string; libraryType: string; groupID?: number }> {
+    try {
+      const libs: any[] = Zotero.Libraries.getAll();
+      return libs
+        .filter((lib: any) => lib.libraryType === 'user' || lib.libraryType === 'group')
+        .map((lib: any) => ({
+          libraryID: lib.libraryID,
+          name: lib.name,
+          libraryType: lib.libraryType,
+          groupID: lib.groupID,
+        }));
+    } catch (error) {
+      debug(`Failed to get all libraries: ${error}`);
+      return [];
+    }
+  }
+
+  /**
+   * Get all regular items across all indexable libraries (user + groups).
+   */
+  async getAllLibraryItems(): Promise<ZoteroItem[]> {
+    const libraries = this.getAllLibraries();
+    const allItems: ZoteroItem[] = [];
+    for (const lib of libraries) {
+      try {
+        const items = await this.getLibraryItems(lib.libraryID);
+        debug(`Got ${items.length} items from library ${lib.name} (${lib.libraryType})`);
+        allItems.push(...items);
+      } catch (error) {
+        debug(`Failed to get items for library ${lib.name}: ${error}`);
+      }
+    }
+    return allItems;
   }
 
   /**


### PR DESCRIPTION
This PR extends "Update Library Index" so it indexes all visible Zotero libraries—both the personal library and any synced group libraries—instead of only the user library.

## Changes

- **src/utils/zotero-api.ts**: add "getAllLibraries()" and "getAllLibraryItems()" helpers.
- **src/index.ts**: extend BulkScope with "{ type: 'all-libraries' }" and update onIndexLibrary() / checkAndOfferResume() to iterate over every indexable library.
- **src/utils/zotero-api.ts**: allow getCollectionItems() to take an optional libraryId (fixes group-collection resume scope).
- **locale/en-US/zotseek.ftl & zh-CN/zotseek.ftl**: update menu/confirm/resume strings to say "all libraries".
- **src/server/http-tools.ts & mcp-endpoint.ts**: expose an optional library_key parameter on the search tool so callers can restrict results to a specific library.

## Why

Group libraries are common in research teams, but the current indexer only covers My Library. The underlying storage already supports group identities (library_key = 'group:<groupID>'), so the only missing piece was the bulk-index entry point.

## Testing

- Built successfully with npm run build.
- Generated XPI installed in Zotero; "Update All Libraries Index" now includes group-library items.
- Search and PDF links continue to work for both user and group libraries.

Fixes the limitation where group-library items were never indexed.


Closes #41
